### PR TITLE
Prevent a failure when imported not on top-level

### DIFF
--- a/src/scss/utils/_variables.scss
+++ b/src/scss/utils/_variables.scss
@@ -3,19 +3,19 @@
 /// The delimiter of configuration path
 ///
 /// @access private
-$config-delimiter: "." !default;
+$config-delimiter: "." !default !global;
 
 /// The configuration storage
 ///
 /// @access private
-$config-attr: () !default;
+$config-attr: () !default !global;
 
 /// The default configuration storage
 ///
 /// @access private
-$config-default: () !default;
+$config-default: () !default !global;
 
 /// Namespace for settings
 ///
 /// @access public
-$config-namespace: "" !default;
+$config-namespace: "" !default !global;


### PR DESCRIPTION
Thank you for the fantastic lib, it revolutionized the way we're defining and accessing our configuration.

I ran into a problem with `sass-config-manager`. Technically, it's a bug, but it only manifestates itself in a non-traditional setup.

What I've been trying to do (and I have succeeded! :smile:) is to absolutely avoid any global variables, mixins and funcitons.

All my Sass code is split into modules, just like ES6 modules in JavaScript, and they have their local scope. All dependencies are imported locally into moduels and do not leak into global scope.

Normally doing that is not possible in Sass because all variables, mixins and functions defined on top level are automatically global, and there's no `!local` flag.

To work around that, I nest every module under an `@at-root { /* ... */ }` directive. This directive, used without arguments, does not influence the CSS output, but it turns all declarations inside it into local ones.

As a result, all my Sass partials **must** explicitly import their dependencies. This might seem too much routine work at first, but this kind of discipline drastically improves code maintainability and prevents technical debt from accumulating.

The problem with `sass-config-manager` is that its variables are defined without the `!global` flag, but they are accessed with the flag. As a result, if you import `sass-config-manager` not on the top level, it will not work (or work unpredictably, if you combine both top-level and nested importing).

I'm PRing you a quick solution: marking `sass-config-manager` variable definitions to be `!global`.

But I ask you to consider updating your build routine to manufacture two versions of `sass-config-manager`: global and local (with all `!global` flags removed). Currently I'm using a patched local version.
